### PR TITLE
Rename pebble-qemu to pebble-qemu-dev

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,0 +1,3 @@
+{
+    "pebble-qemu": "pebble-qemu-dev"
+}

--- a/pebble-qemu-dev.rb
+++ b/pebble-qemu-dev.rb
@@ -1,4 +1,4 @@
-class PebbleQemu < Formula
+class PebbleQemuDev < Formula
   homepage "https://github.com/pebble/qemu"
   url "git@github.com:pebble/qemu-dev.git", :revision => "74ee1bd", :using => :git
   head "git@github.com:pebble/qemu-dev.git", :using => :git


### PR DESCRIPTION
In _theory_, Homebrew will handle this and silently do the right thing.
