### PR TITLE
Add pixman dependency to pebble-qemu-dev

### DIFF
--- a/pebble-qemu-dev.rb
+++ b/pebble-qemu-dev.rb
@@ -16,6 +16,7 @@ class PebbleQemuDev < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "pixman" => :build
 
   def install
     system "./configure", "--disable-werror",


### PR DESCRIPTION
Without this homebrew will just end up using the internal version of pixman that's included as a submodule, but that version doesn't like to build on OS X (see https://github.com/Homebrew/homebrew/issues/41056).
